### PR TITLE
Add signed mail support

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,17 +185,36 @@ function pluckAllAttachments(mails) {
     if (!m.data || !m.data.payload || !m.data.payload.parts) {
       return undefined;
     }
-    return _.map(m.data.payload.parts, (p) => {
-      if (!p.body || !p.body.attachmentId) {
-        return undefined;
-      }
-      const attachment = {
-        mailId: m.data.id,
-        name: p.filename,
-        id: p.body.attachmentId
-      };
-      return attachment;
-    })
+    if (m.data.payload.mimeType === "multipart/signed") {
+      return _.flatten(_.map(m.data.payload.parts, (p) => {
+        if (p.mimeType !== "multipart/mixed") {
+          return undefined;
+        }
+        return _.map(p.parts, (pp) => {
+          if (!pp.body || !pp.body.attachmentId) {
+            return undefined;
+          }
+          const attachment = {
+            mailId: m.data.id,
+            name: pp.filename,
+            id: pp.body.attachmentId
+          };
+          return attachment;
+        })
+      }))
+    } else {
+      return _.map(m.data.payload.parts, (p) => {
+        if (!p.body || !p.body.attachmentId) {
+          return undefined;
+        }
+        const attachment = {
+          mailId: m.data.id,
+          name: p.filename,
+          id: p.body.attachmentId
+        };
+        return attachment;
+      })
+  }
   })));
 }
 


### PR DESCRIPTION
This should be hopefully enough to support getting the attachments of signed mails. At least I was able to download the attached invoices that a company sends me. Regular attachments also still worked.
Another user also raised this issue some time ago https://github.com/munir131/attachment-downloader/issues/21